### PR TITLE
Making the VerticalToolbar only show up on desktop screens by default…

### DIFF
--- a/components/toolbars/VerticalToolbar.module.css
+++ b/components/toolbars/VerticalToolbar.module.css
@@ -20,7 +20,7 @@
   top: 210px important; /* Adjust the position as needed */
   right: -400px; /* Distance from the right of the viewport */
   z-index: 110; /* Ensure it's above other content */
-  transform: translateY(50px);
+  transform: translateY(55px);
 }
 
 /* Adjustments for smaller screens, hide toolbarStack and show menuButton */


### PR DESCRIPTION
…, and show a hamburger icon to activate on smaller screens like mobile devices